### PR TITLE
npx prisma init でSupport for loading ES Module in require() is an experimental feature and might change at any time というエラーが出た場合の原因と対処法

### DIFF
--- a/content/19.prisma-error.md
+++ b/content/19.prisma-error.md
@@ -1,0 +1,28 @@
+---
+title: "npx prisma init でSupport for loading ES Module in require() is an experimental feature and might change at any time というエラーが出た場合の原因と対処法"
+description: "Prisma を使用した際に見慣れないエラーに遭遇したので備忘録として残す。"
+emoji: "&#x1f612;"
+createdAt: "2024-12-22"
+updatedAt: "2024-12-22"
+tags: ['Prisma']
+---
+
+## エラーの内容
+
+npx prisma init を実行した際に以下のようなエラーメッセージが出てしまい、初期化に失敗してしまいました。
+
+> (node:30187) ExperimentalWarning: Support for loading ES Module in require() is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+Error: (0 , KSe.isError) is not a function
+
+## エラーの原因
+
+原因は、Node.js のバージョンでした。
+
+私は v23.0.0 を使用していましたが、2024年12月22日の時点で Prisma が Node.js の v23 をサポートしていませんでした。
+
+## エラーの対処法
+
+v22.11.0 にバージョンを下げて再度 npx prisma init を実行すると無事に成功しました。
+
+サポート状況は[公式サイト](https://www.prisma.io/docs/orm/reference/system-requirements#system-requirements)に記載されているのでバージョンを変更する際に参考するようにしてください。


### PR DESCRIPTION
resolve #89 